### PR TITLE
PRODENG-1550 go mod migrate

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-richard-barrett@outlook.com.
+tools@mirantis.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 A terraform provider to control configuration across multiple Mirantis Products.
 
-[![CodeQL](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/codeql-analysis.yml)
-[![Go](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/go.yml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/Richard-Barrett/terraform-provider-mirantis.svg)](https://pkg.go.dev/github.com/Richard-Barrett/terraform-provider-mirantis)
-[![Greetings](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/greetings.yml/badge.svg?branch=main)](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/greetings.yml)
-[![Labeler](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/label.yml/badge.svg)](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/label.yml)
-[![release](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/release.yml/badge.svg)](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/release.yml)
-[![tag](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/tag.yml/badge.svg)](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/tag.yml)
-[![tfsec](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/tfsec.yaml/badge.svg)](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/tfsec.yaml)
-[![validate](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/validate.yml/badge.svg)](https://github.com/Richard-Barrett/terraform-provider-mirantis/actions/workflows/validate.yml)
+[![CodeQL](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/codeql-analysis.yml)
+[![Go](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/go.yml/badge.svg?branch=main)](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/go.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Mirantis/terraform-provider-mirantis.svg)](https://pkg.go.dev/github.com/Mirantis/terraform-provider-mirantis)
+[![Greetings](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/greetings.yml/badge.svg?branch=main)](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/greetings.yml)
+[![Labeler](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/label.yml/badge.svg)](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/label.yml)
+[![release](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/release.yml/badge.svg)](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/release.yml)
+[![tag](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/tag.yml/badge.svg)](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/tag.yml)
+[![tfsec](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/tfsec.yaml/badge.svg)](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/tfsec.yaml)
+[![validate](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/validate.yml/badge.svg)](https://github.com/Mirantis/terraform-provider-mirantis/actions/workflows/validate.yml)
 
 ## contributions
 

--- a/dist/config.yaml
+++ b/dist/config.yaml
@@ -1,7 +1,7 @@
 project_name: terraform-provider-mirantis
 release:
   github:
-    owner: Richard-Barrett
+    owner: Mirantis
     name: terraform-provider-mirantis
   name_template: '{{.Tag}}'
   extra_files:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Richard-Barrett/terraform-provider-mirantis
+module github.com/Mirantis/terraform-provider-mirantis
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
   "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
   "github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-  "github.com/Richard-Barrett/terraform-provider-mirantis/mirantis"
+  "github.com/Mirantis/terraform-provider-mirantis/mirantis"
 )
 
 func main() {


### PR DESCRIPTION
# Description

- drops github.com/Richard-Barret references.
- - uses a google group for conde-of-conduct email address.

## Issue

https://mirantis.jira.com/browse/PRODENG-1550

Signed-off-by: James Nesbitt <jnesbitt@mirantis.com>